### PR TITLE
Add dependency bot to update versions

### DIFF
--- a/.github/dependentbot.yml
+++ b/.github/dependentbot.yml
@@ -15,3 +15,14 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "pandas"
         update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
This skips major version updates for numpy and pandas (to avoid breaking changes).

The bot groups all dependency updates together in a single PR.