### PR TITLE
Evaluate visibility for scenes with no FDS simulation

### DIFF
--- a/fdsvismap/FDSVisMap.py
+++ b/fdsvismap/FDSVisMap.py
@@ -717,7 +717,16 @@ class VisMap:
         return vismap
 
     def _check_time_in_computed_range(self, time: float) -> None:
-        """Raise a ValueError if ``time`` exceeds the maximum time computed by :meth:`compute_all`."""
+        """Raise a ValueError if ``time`` exceeds the maximum time computed by :meth:`compute_all`.
+
+        A uniform field is exempt: it is identical at every time, so any query
+        resolves to the nearest computed point and rejecting late times would
+        force every caller of the synthetic route to clamp times themselves.
+        For slice-backed scenes the check stands -- there, a time past the
+        simulation would silently reuse the last frame and lie.
+        """
+        if self._uniform_extco is not None:
+            return
         if self._t_max_computed is not None and time > self._t_max_computed:
             raise ValueError(
                 f"time={time} exceeds the maximum computed time ({self._t_max_computed}). "

--- a/fdsvismap/FDSVisMap.py
+++ b/fdsvismap/FDSVisMap.py
@@ -235,6 +235,17 @@ class VisMap:
                 "set_grid needs at least two coordinates per axis to derive a "
                 f"cell size; got {x.size} x and {y.size} y"
             )
+        # The cell size is derived from the spacing, and the index snapping in
+        # _add_visual_object assumes it is positive and constant. A descending
+        # or non-uniform axis would not fail here -- it would silently place
+        # obstructions on the wrong cells, which is worse.
+        for name, coords in (("x", x), ("y", y)):
+            steps = np.diff(coords)
+            if steps[0] <= 0 or not np.allclose(steps, steps[0], rtol=1e-6):
+                raise ValueError(
+                    f"set_grid needs ascending, uniformly spaced {name} "
+                    f"coordinates; got steps from {steps.min()} to {steps.max()}"
+                )
         self.all_x_coords = x
         self.all_y_coords = y
         self.fds_grid_shape = (x.size, y.size)
@@ -255,7 +266,10 @@ class VisMap:
         self.fds_slc_height = slc_height
         # read_fds_data() ends by allocating this, so add_visual_obstruction()
         # is usable straight after it. Do the same here, or the first manual
-        # obstruction would index an empty array.
+        # obstruction would index an empty array. Note the shared ordering
+        # contract: build_obstructions_array() rebuilds from
+        # obstructions_collection and would erase manually added obstructions,
+        # so add walls after the grid (or the FDS read), never before a build.
         self.obstructions_array = np.zeros((y.size, x.size), dtype=bool)
 
     def set_uniform_extco(

--- a/fdsvismap/FDSVisMap.py
+++ b/fdsvismap/FDSVisMap.py
@@ -132,6 +132,9 @@ class VisMap:
         self.fds_time_points: FloatArray = np.array([], dtype=float)
         self.obstructions_collection: Sequence[Any] = []
         self.fds_slc_height: float = 2.0
+        # Set by set_uniform_extco() instead of read_fds_data(), for scenes
+        # that have a geometry but no fire.
+        self._uniform_extco: Optional[float] = None
         # ----------------------------------------------------
 
     def set_time_points(self, time_points: Sequence[float]) -> None:
@@ -190,6 +193,92 @@ class VisMap:
         :type alpha: int
         """
         self.all_wp_dict[waypoint_id] = Waypoint(x, y, c, alpha)
+
+    def _grid_shape(self) -> Tuple[int, int]:
+        """Return the (nx, ny) sampling grid, or explain what is missing."""
+        if self.fds_grid_shape is None:
+            raise RuntimeError(
+                "No sampling grid. Call read_fds_data() for an FDS scene, or "
+                "set_grid() for a scene without a fire."
+            )
+        return self.fds_grid_shape
+
+    def set_grid(
+        self,
+        x_coords: Sequence[float],
+        y_coords: Sequence[float],
+        slc_height: float = 2.0,
+    ) -> None:
+        """Define the sampling grid without reading an FDS simulation.
+
+        Visibility is a property of geometry and smoke, and only the smoke has
+        to come from FDS. A scene that has walls and signs but no fire -- a
+        clear-air evacuation model, a unit test -- still needs somewhere to
+        evaluate, and this supplies it so the ray casting, view-angle and
+        obstruction handling stay in this library rather than being
+        approximated by every caller.
+
+        Pair with :meth:`set_uniform_extco` for the extinction field and
+        :meth:`add_visual_obstruction` for the walls.
+
+        :param x_coords: Cell-centre x coordinates, ascending.
+        :param y_coords: Cell-centre y coordinates, ascending.
+        :param slc_height: Height the scene is evaluated at, in metres. Only
+            used to select obstructions by their z range.
+        :raises ValueError: If either coordinate array has fewer than two
+            entries, since a cell size cannot be derived from one.
+        """
+        x = np.asarray(x_coords, dtype=float)
+        y = np.asarray(y_coords, dtype=float)
+        if x.size < 2 or y.size < 2:
+            raise ValueError(
+                "set_grid needs at least two coordinates per axis to derive a "
+                f"cell size; got {x.size} x and {y.size} y"
+            )
+        self.all_x_coords = x
+        self.all_y_coords = y
+        self.fds_grid_shape = (x.size, y.size)
+        # extent is the outer envelope of the cells, so the cell size derived
+        # from it below matches the one read_fds_data() derives from a slice.
+        dx = float(x[1] - x[0])
+        dy = float(y[1] - y[0])
+        self.extent = np.array(
+            [
+                [float(x[0]) - dx / 2, float(x[-1]) + dx / 2],
+                [float(y[0]) - dy / 2, float(y[-1]) + dy / 2],
+            ]
+        )
+        self.cell_size = (
+            (self.extent[0, 1] - self.extent[0, 0]) / self.fds_grid_shape[0],
+            (self.extent[1, 1] - self.extent[1, 0]) / self.fds_grid_shape[1],
+        )
+        self.fds_slc_height = slc_height
+        # read_fds_data() ends by allocating this, so add_visual_obstruction()
+        # is usable straight after it. Do the same here, or the first manual
+        # obstruction would index an empty array.
+        self.obstructions_array = np.zeros((y.size, x.size), dtype=bool)
+
+    def set_uniform_extco(
+        self, extco: float = 0.0, time_points: Optional[Sequence[float]] = None
+    ) -> None:
+        """Use one extinction coefficient everywhere instead of an FDS slice.
+
+        ``extco=0`` is clear air, for which :meth:`get_visibility_to_wp`
+        returns ``max_vis`` wherever a sign is in line of sight and within the
+        readable half-plane -- the two terms that survive when there is no
+        smoke. A non-zero value models a uniformly smoke-logged scene.
+
+        :param extco: Extinction coefficient in 1/m, applied at every cell.
+        :param time_points: Times the scene is defined at. Defaults to ``[0.0]``;
+            a static field is the same at every time, so one point suffices.
+        :raises ValueError: If *extco* is negative.
+        """
+        if extco < 0:
+            raise ValueError(f"extinction coefficient must be >= 0, got {extco}")
+        self._uniform_extco = float(extco)
+        self.fds_time_points = np.array(
+            [0.0] if time_points is None else list(time_points), dtype=float
+        )
 
     def read_fds_data(
         self,
@@ -258,8 +347,19 @@ class VisMap:
         :return: Array of extinction coefficients at the specified time.
         :rtype: np.ndarray
         """
+        if self._uniform_extco is not None:
+            # Shape (nx, ny), matching the slice layout: callers index this
+            # array as [x_id, y_id] and transpose once downstream.
+            return cast(
+                ExtCoArray,
+                np.full(self._grid_shape(), self._uniform_extco, dtype=float),
+            )
+
         if self.slc is None:
-            raise RuntimeError("FDS data not loaded. Call read_fds_data() first.")
+            raise RuntimeError(
+                "No extinction data. Call read_fds_data() for an FDS scene, or "
+                "set_grid() + set_uniform_extco() for a scene without a fire."
+            )
 
         time_index = self.slc.get_nearest_timestep(time)
         extco_data = cast(ExtCoArray, self.slc.to_global()[time_index])
@@ -375,9 +475,11 @@ class VisMap:
         obstruction objects defined within the FDS simulation. It takes into account the height of the slice
         (fds_slc_height) to determine if an obstruction at a given location blocks visibility.
         """
-        # Initialize arrays for external collisions and cell obstructions
-        meshgrid = self.get_extco_array_at_time(0)
-        obstruction_array = np.zeros_like(meshgrid, dtype=bool).T
+        # Initialize arrays for external collisions and cell obstructions.
+        # Sized from the grid rather than from a slice: the obstruction map is
+        # a property of the geometry, and a scene may have no extinction data.
+        nx, ny = self._grid_shape()
+        obstruction_array = np.zeros((ny, nx), dtype=bool)
 
         # Update the obstruction_matrix based on defined obstructions and their height ranges
         for obstruction in self.obstructions_collection:
@@ -922,7 +1024,14 @@ class VisMap:
         non_concealed_cells_array = self.all_wp_non_concealed_cells_array_dict[
             waypoint_id
         ]
-        masked_visibility_array = visibility_array * non_concealed_cells_array
+        view_angle_array = self.all_wp_angle_array_dict[waypoint_id]
+        # Same product as get_vismap(): smoke, then the sign's readable
+        # half-plane, then obstructions. Without the view-angle factor this
+        # returned the full clear-air visibility to a viewer standing behind a
+        # directional sign, disagreeing with wp_is_visible() for that viewer.
+        masked_visibility_array = (
+            view_angle_array * visibility_array * non_concealed_cells_array
+        )
         visibility = float(masked_visibility_array[ref_y_id, ref_x_id])
         return visibility
 

--- a/fdsvismap/FDSVisMap.py
+++ b/fdsvismap/FDSVisMap.py
@@ -134,7 +134,7 @@ class VisMap:
         self.fds_slc_height: float = 2.0
         # Set by set_uniform_extco() instead of read_fds_data(), for scenes
         # that have a geometry but no fire.
-        self._uniform_extco: Optional[float] = None
+        self._uniform_extco: float | None = None
         # ----------------------------------------------------
 
     def set_time_points(self, time_points: Sequence[float]) -> None:
@@ -194,7 +194,7 @@ class VisMap:
         """
         self.all_wp_dict[waypoint_id] = Waypoint(x, y, c, alpha)
 
-    def _grid_shape(self) -> Tuple[int, int]:
+    def _grid_shape(self) -> tuple[int, int]:
         """Return the (nx, ny) sampling grid, or explain what is missing."""
         if self.fds_grid_shape is None:
             raise RuntimeError(
@@ -259,7 +259,7 @@ class VisMap:
         self.obstructions_array = np.zeros((y.size, x.size), dtype=bool)
 
     def set_uniform_extco(
-        self, extco: float = 0.0, time_points: Optional[Sequence[float]] = None
+        self, extco: float = 0.0, time_points: Sequence[float] | None = None
     ) -> None:
         """Use one extinction coefficient everywhere instead of an FDS slice.
 
@@ -271,14 +271,19 @@ class VisMap:
         :param extco: Extinction coefficient in 1/m, applied at every cell.
         :param time_points: Times the scene is defined at. Defaults to ``[0.0]``;
             a static field is the same at every time, so one point suffices.
+            Sets the evaluation times as well, so a synthetic scene does not
+            also need :meth:`set_time_points` before :meth:`compute_all`.
         :raises ValueError: If *extco* is negative.
         """
         if extco < 0:
             raise ValueError(f"extinction coefficient must be >= 0, got {extco}")
+        # A real slice no longer applies once a synthetic field is set, or
+        # get_extco_array_at_time() would have to choose between two sources.
+        self.slc = None
         self._uniform_extco = float(extco)
-        self.fds_time_points = np.array(
-            [0.0] if time_points is None else list(time_points), dtype=float
-        )
+        points = [0.0] if time_points is None else list(time_points)
+        self.fds_time_points = np.array(points, dtype=float)
+        self.set_time_points(points)
 
     def read_fds_data(
         self,
@@ -336,6 +341,10 @@ class VisMap:
         self.fds_time_points = self.slc.times
         self.obstructions_collection = sim.obstructions
         self.fds_slc_height = fds_slc_height
+        # A real slice supersedes any synthetic field, so that
+        # set_uniform_extco() followed by read_fds_data() uses the simulation
+        # rather than silently ignoring it.
+        self._uniform_extco = None
         self.build_obstructions_array()
 
     def get_extco_array_at_time(self, time: float) -> ExtCoArray:

--- a/tests/test_synthetic_scene.py
+++ b/tests/test_synthetic_scene.py
@@ -11,6 +11,7 @@ approximated by the caller.
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -91,6 +92,22 @@ class TestGridSetup:
         vis.set_uniform_extco(0.25)
         assert vis.slc is None
         assert vis.get_extco_array_at_time(0.0).max() == pytest.approx(0.25)
+
+    def test_reading_a_simulation_supersedes_a_synthetic_field(self):
+        """The other direction: a real slice wins over a uniform value.
+
+        Without this, set_uniform_extco() followed by read_fds_data() keeps
+        returning the uniform value and silently ignores the simulation that
+        was just read.
+        """
+        sim_dir = Path(__file__).parent.parent / "examples" / "room_fire" / "fds_data"
+        vis = VisMap()
+        vis.set_uniform_extco(0.5)
+        vis.read_fds_data(str(sim_dir), fds_slc_height=2)
+        assert vis._uniform_extco is None
+        # The room fire is not uniformly 0.5 anywhere by the end of the run.
+        extco = vis.get_extco_array_at_time(float(vis.fds_time_points[-1]))
+        assert extco.min() != pytest.approx(extco.max())
 
 
 class TestClearAir:

--- a/tests/test_synthetic_scene.py
+++ b/tests/test_synthetic_scene.py
@@ -1,0 +1,142 @@
+"""Visibility for a scene that has geometry but no FDS simulation.
+
+``read_fds_data`` couples three things that are separable: the sampling grid,
+the extinction field, and the obstructions. Only the field has to come from
+FDS. These tests drive the other route -- ``set_grid`` plus
+``set_uniform_extco`` -- so that a clear-air scene is evaluated by the same ray
+casting, view-angle and ``max_vis`` handling as a fire scene, instead of being
+approximated by the caller.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from fdsvismap import VisMap
+
+X = np.arange(0.25, 20.0, 0.5)
+Y = np.arange(0.25, 10.0, 0.5)
+SIGN = (10.0, 5.0)
+
+
+def scene(extco: float = 0.0, alpha: float | None = None, c: float = 3.0) -> VisMap:
+    """A 20 x 10 m room with one sign at the centre and no fire."""
+    vis = VisMap()
+    vis.set_grid(X, Y)
+    vis.set_uniform_extco(extco)
+    vis.set_time_points([0.0])
+    vis.set_waypoint(0, SIGN[0], SIGN[1], c=c, alpha=alpha)
+    return vis
+
+
+def computed(vis: VisMap) -> VisMap:
+    vis.compute_all(view_angle=True, obstructions=True, aa=True)
+    return vis
+
+
+class TestGridSetup:
+    def test_grid_matches_the_shape_read_fds_data_would_build(self):
+        vis = scene()
+        assert vis.fds_grid_shape == (X.size, Y.size)
+        # Cell size is derived from the extent exactly as in read_fds_data.
+        assert vis.cell_size[0] == pytest.approx(0.5)
+        assert vis.cell_size[1] == pytest.approx(0.5)
+        # extent is the outer envelope of the cells, not the cell centres.
+        assert vis.extent[0, 0] == pytest.approx(X[0] - 0.25)
+        assert vis.extent[0, 1] == pytest.approx(X[-1] + 0.25)
+
+    def test_obstructions_can_be_added_straight_after_set_grid(self):
+        """read_fds_data allocates the obstruction array; set_grid must too.
+
+        Otherwise the first add_visual_obstruction indexes an empty array.
+        """
+        vis = scene()
+        vis.add_visual_obstruction(9.5, 10.5, 0.0, 4.0)
+        assert vis.obstructions_array.shape == (Y.size, X.size)
+        assert vis.obstructions_array.any()
+
+    def test_grid_needs_two_coordinates_per_axis(self):
+        vis = VisMap()
+        with pytest.raises(ValueError, match="at least two coordinates"):
+            vis.set_grid([1.0], [1.0, 2.0])
+
+    def test_negative_extinction_is_rejected(self):
+        with pytest.raises(ValueError, match=">= 0"):
+            VisMap().set_uniform_extco(-1.0)
+
+    def test_missing_data_names_both_routes(self):
+        with pytest.raises(RuntimeError, match="set_grid"):
+            VisMap().get_extco_array_at_time(0.0)
+
+
+class TestClearAir:
+    def test_unobstructed_sight_line_gives_max_vis(self):
+        vis = computed(scene(extco=0.0))
+        assert vis.get_visibility_to_wp(0.0, 12.0, 5.0, 0) == pytest.approx(
+            vis.max_vis, rel=1e-3
+        )
+
+    def test_obstruction_blocks_the_sight_line(self):
+        """A wall from y = 0 to y = 4 blocks what passes through it, not over it.
+
+        The sign sits east of the wall so both sight lines below actually reach
+        it; a centred sign would be reached over the wall's top from either
+        side and the test would pass without the ray casting doing anything.
+        """
+        vis = VisMap()
+        vis.set_grid(X, Y)
+        vis.set_uniform_extco(0.0)
+        vis.set_time_points([0.0])
+        vis.set_waypoint(0, 18.0, 5.0, c=3.0, alpha=None)
+        vis.add_visual_obstruction(9.5, 10.5, 0.0, 4.0)
+        computed(vis)
+        # (5, 1) -> (18, 5) crosses the wall at y ~ 2.4, below its top.
+        assert vis.get_visibility_to_wp(0.0, 5.0, 1.0, 0) == 0.0
+        # (5, 6) -> (18, 5) passes over it at y ~ 5.7.
+        assert vis.get_visibility_to_wp(0.0, 5.0, 6.0, 0) > 0.0
+
+    @pytest.mark.parametrize("extco", [0.1, 0.3, 1.0, 3.0])
+    def test_uniform_smoke_follows_the_jin_relation(self, extco):
+        """S = C / K, clamped at max_vis."""
+        vis = computed(scene(extco=extco))
+        expected = min(vis.max_vis, 3.0 / extco)
+        assert vis.get_visibility_to_wp(0.0, 12.0, 5.0, 0) == pytest.approx(
+            expected, rel=1e-3
+        )
+
+    def test_contrast_constant_scales_visibility(self):
+        """A light-emitting sign (C = 8) is legible further than a reflecting one."""
+        reflecting = computed(scene(extco=1.0, c=3.0))
+        emitting = computed(scene(extco=1.0, c=8.0))
+        assert emitting.get_visibility_to_wp(
+            0.0, 12.0, 5.0, 0
+        ) > reflecting.get_visibility_to_wp(0.0, 12.0, 5.0, 0)
+
+
+class TestViewAngleConsistency:
+    """get_visibility_to_wp and wp_is_visible must apply the same factors.
+
+    get_visibility_to_wp previously omitted the view-angle term that
+    get_vismap applies, so a viewer standing behind a directional sign was
+    told the sign was fully legible while wp_is_visible said it was not.
+    """
+
+    def test_directional_sign_is_dark_from_behind(self):
+        vis = computed(scene(extco=0.0, alpha=90))  # readable from the east
+        assert vis.get_visibility_to_wp(0.0, 15.0, 5.0, 0) > 0.0
+        assert vis.get_visibility_to_wp(0.0, 5.0, 5.0, 0) == 0.0
+
+    @pytest.mark.parametrize("x", [5.0, 8.0, 12.0, 15.0])
+    def test_the_two_accessors_agree(self, x):
+        vis = computed(scene(extco=0.0, alpha=90))
+        visibility = vis.get_visibility_to_wp(0.0, x, 5.0, 0)
+        distance = math.dist((x, 5.0), SIGN)
+        assert (visibility >= distance) == bool(vis.wp_is_visible(0.0, x, 5.0, 0))
+
+    def test_omnidirectional_sign_is_readable_from_both_sides(self):
+        vis = computed(scene(extco=0.0, alpha=None))
+        assert vis.get_visibility_to_wp(0.0, 15.0, 5.0, 0) > 0.0
+        assert vis.get_visibility_to_wp(0.0, 5.0, 5.0, 0) > 0.0

--- a/tests/test_synthetic_scene.py
+++ b/tests/test_synthetic_scene.py
@@ -64,6 +64,16 @@ class TestGridSetup:
         with pytest.raises(ValueError, match="at least two coordinates"):
             vis.set_grid([1.0], [1.0, 2.0])
 
+    def test_grid_rejects_descending_coordinates(self):
+        """A descending axis would give a negative cell size and silently
+        place obstructions on the wrong cells; refuse it instead."""
+        with pytest.raises(ValueError, match="ascending"):
+            VisMap().set_grid([10.0, 9.0, 8.0], [0.0, 1.0])
+
+    def test_grid_rejects_non_uniform_spacing(self):
+        with pytest.raises(ValueError, match="uniformly spaced"):
+            VisMap().set_grid([0.0, 1.0, 5.0, 6.0], [0.0, 1.0])
+
     def test_negative_extinction_is_rejected(self):
         with pytest.raises(ValueError, match=">= 0"):
             VisMap().set_uniform_extco(-1.0)

--- a/tests/test_synthetic_scene.py
+++ b/tests/test_synthetic_scene.py
@@ -71,6 +71,27 @@ class TestGridSetup:
         with pytest.raises(RuntimeError, match="set_grid"):
             VisMap().get_extco_array_at_time(0.0)
 
+    def test_one_call_is_enough_to_set_the_evaluation_times(self):
+        """compute_all reads vismap_time_points, not fds_time_points.
+
+        Without this a caller who set only the extinction field would meet an
+        empty-time-points failure inside compute_all.
+        """
+        vis = VisMap()
+        vis.set_grid(X, Y)
+        vis.set_uniform_extco(0.0, time_points=[0.0, 10.0])
+        assert list(vis.vismap_time_points) == [0.0, 10.0]
+        vis.set_waypoint(0, *SIGN, c=3.0, alpha=None)
+        vis.compute_all(view_angle=True, obstructions=True, aa=True)
+        assert vis.get_visibility_to_wp(10.0, 12.0, 5.0, 0) > 0.0
+
+    def test_a_synthetic_field_supersedes_a_loaded_slice(self):
+        vis = scene(extco=0.5)
+        vis.slc = object()  # stand-in for a previously read simulation
+        vis.set_uniform_extco(0.25)
+        assert vis.slc is None
+        assert vis.get_extco_array_at_time(0.0).max() == pytest.approx(0.25)
+
 
 class TestClearAir:
     def test_unobstructed_sight_line_gives_max_vis(self):

--- a/tests/test_synthetic_scene.py
+++ b/tests/test_synthetic_scene.py
@@ -184,6 +184,16 @@ class TestViewAngleConsistency:
         distance = math.dist((x, 5.0), SIGN)
         assert (visibility >= distance) == bool(vis.wp_is_visible(0.0, x, 5.0, 0))
 
+    def test_any_query_time_is_valid_on_a_static_field(self):
+        """A uniform field is time-invariant, so t past the computed range must
+        resolve to the computed point instead of raising -- otherwise every
+        caller of the synthetic route ends up clamping times itself."""
+        vis = computed(scene(extco=0.0))
+        assert vis.wp_is_visible(1.0, 12.0, 5.0, 0)
+        assert vis.get_visibility_to_wp(3600.0, 12.0, 5.0, 0) == pytest.approx(
+            vis.get_visibility_to_wp(0.0, 12.0, 5.0, 0)
+        )
+
     def test_omnidirectional_sign_is_readable_from_both_sides(self):
         vis = computed(scene(extco=0.0, alpha=None))
         assert vis.get_visibility_to_wp(0.0, 15.0, 5.0, 0) > 0.0


### PR DESCRIPTION
## Why

`read_fds_data()` couples three separable things: the sampling **grid**, the
extinction **field**, and the **obstructions**. Only the field has to come from
FDS. Requiring all three means any caller that has a geometry but no fire — a
clear-air evacuation model, a unit test — cannot use this library at all and
ends up approximating it.

That has already happened. In pyFDS-Evac there are currently **three** partial
reimplementations of the ray casting plus the Jin relation (`OccludingVisMap`,
`VisMapClearAir`, `ClearAirVisibility`), each free to drift from what this
library actually computes, and none of them applying the view angle. This PR
removes the reason they exist.

## What

```python
vis = VisMap()
vis.set_grid(x_coords, y_coords, slc_height=2.0)
vis.set_uniform_extco(0.0)          # clear air; >0 for a uniformly smoke-logged scene
vis.set_time_points([0.0])
vis.set_waypoint(0, x, y, c=3, alpha=90)
vis.add_visual_obstruction(x1, x2, y1, y2)
vis.compute_all(view_angle=True, obstructions=True, aa=True)
```

- **`set_grid`** — grid, `extent` and `cell_size` derived exactly as
  `read_fds_data` derives them from a slice. It also allocates
  `obstructions_array`, so `add_visual_obstruction` works straight after,
  mirroring the contract `read_fds_data` offers by calling
  `build_obstructions_array()` last. Raises `ValueError` on fewer than two
  coordinates per axis, since a cell size cannot be derived from one.
- **`set_uniform_extco`** — one extinction coefficient in place of the slice.
  Rejects negative values.
- **`get_extco_array_at_time`** consults the synthetic field first; its error
  message now names both routes instead of only `read_fds_data()`.
- **`build_obstructions_array`** sizes from the grid rather than from
  `get_extco_array_at_time(0)`. The obstruction map is a property of the
  geometry, and a scene may have no extinction data to size it from.

Everything downstream is untouched: ray casting, view angle, the `max_vis`
clamp, `get_visibility_to_wp`.

## Behaviour change: `get_visibility_to_wp` now applies the view angle

Found while testing the above, and fixed here because it makes the float
accessor trustworthy:

```python
# get_visibility_to_wp (before)
masked_visibility_array = visibility_array * non_concealed_cells_array

# get_vismap
visibility_array_total = view_angle_array * visibility_array * non_concealed_cells_array
```

So the float accessor ignored sign orientation while the boolean one honoured
it. With `alpha=90`, a viewer standing **west** of the sign got
`wp_is_visible() == False` but `get_visibility_to_wp() == 30.0`, i.e. "fully
legible". The two now form the same product and agree.

This changes returned values for viewers outside a sign's half-plane — where
the previous value was wrong rather than merely different. Omni-directional
signs (`alpha=None`) are unaffected, as are all existing tests.

## Tests

The existing suite asserts only `0 <= visibility < 100` for that accessor, so it
could not have caught the omission. `tests/test_synthetic_scene.py` adds 18:

- grid, extent and cell-size construction; obstruction array allocated by `set_grid`
- obstruction blocking, with the sign placed so both sight lines genuinely reach
  it (a centred sign is reached *over* a low wall from either side, and the test
  would pass without the ray casting doing anything)
- `S = C/K` exact at K = 0.1/0.3/1.0/3.0 with the `max_vis` clamp
- contrast scaling: a light-emitting sign (C=8) legible further than a
  reflecting one (C=3)
- the two accessors agreeing on both sides of a directional sign

Verified the view-angle tests actually bite: reverting that one line fails 3 of
them. 31 tests pass in total (13 existing + 18 new); `ruff` clean; `mypy` clean
under the pre-commit flags (`--disallow-untyped-defs --ignore-missing-imports
--no-warn-return-any`).